### PR TITLE
ci: Create initial CI workflow

### DIFF
--- a/.github/workflows/kubectl-az.yml
+++ b/.github/workflows/kubectl-az.yml
@@ -1,0 +1,197 @@
+name: Microsoft Azure CLI kubectl plugin CI
+env:
+  GO_VERSION: 1.17 # TODO: Update
+  AZURE_PREFIX: kubectl-az-ci
+concurrency:
+  # Only one workflow can run at a time unless
+  # we create a new AKS cluster per github_ref (branch)
+  group: kubectl-az-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build kubectl-az
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ linux, darwin, windows ]
+        arch: [ amd64, arm64 ]
+        exclude:
+          - os: windows
+            arch: arm64
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Cache Go
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build and generate tarball
+        run: |
+          target=kubectl-az-${{ matrix.os }}-${{ matrix.arch }}
+
+          make $target
+
+          binary_name=kubectl-az
+          if [ ${{ matrix.os }} = "windows" ]; then
+            binary_name=kubectl-az.exe
+          fi
+
+          # Prepare binary as artifact, it will be used by other jobs
+          mv $target $binary_name
+          tar --sort=name --owner=root:0 --group=root:0 \
+            -czf ${target}.tar.gz \
+            $binary_name LICENSE
+      - name: Add kubectl-az-${{ matrix.os }}-${{ matrix.arch }}.tar.gz as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kubectl-az-${{ matrix.os }}-${{ matrix.arch }}
+          path: kubectl-az-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+
+  unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Cache Go
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        run: make unit-test
+
+  create-aks-cluster:
+    name: Create AKS cluster
+    needs: [ build, unit-tests ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64 ]
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Create AKS cluster ${{ env.AZURE_PREFIX }}-${{ matrix.arch }}-cluster
+        shell: bash
+        run: |
+          az aks create \
+            --resource-group ${{ env.AZURE_PREFIX }}-rg \
+            --name ${{ env.AZURE_PREFIX }}-${{ matrix.arch }}-cluster \
+            --node-count 1 \
+            --generate-ssh-keys
+
+  delete-aks-cluster:
+    name: Delete AKS cluster
+    if: always()
+    needs: [ integration-tests ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64 ]
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Delete AKS cluster ${{ env.AZURE_PREFIX }}-${{ matrix.arch }}-cluster
+        shell: bash
+        run: |
+          az aks delete \
+            --resource-group ${{ env.AZURE_PREFIX }}-rg \
+            --name ${{ env.AZURE_PREFIX }}-${{ matrix.arch }}-cluster \
+            --yes
+
+  integration-tests:
+    name: Run integration tests
+    needs: [ build, unit-tests , create-aks-cluster ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # 'run-command' is not supported in parallel for a given node
+      # (don't want to create a new cluster for each OS)
+      max-parallel: 1
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        arch: [ amd64 ] # TODO: Support ARM
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set environment variables
+        shell: bash
+        run: |
+          case ${{ matrix.os }} in
+            ubuntu-latest)
+              echo "os=linux" >> $GITHUB_ENV
+              ;;
+            macOS-latest)
+              echo "os=darwin" >> $GITHUB_ENV
+              ;;
+            windows-latest)
+              echo "os=windows" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "Not supported OS: ${{ matrix.os }}"
+              exit 1
+              ;;
+          esac
+      - name: Get kubectl-az from artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: kubectl-az-${{ env.os }}-${{ matrix.arch }}
+      - name: Prepare kubectl-az binary
+        shell: bash
+        run: |
+          tar zxvf kubectl-az-${{ env.os }}-${{ matrix.arch }}.tar.gz
+          chmod +x kubectl-az
+          ls -la
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Set AKS cluster context
+        uses: azure/aks-set-context@v3
+        with:
+          cluster-name: ${{ env.AZURE_PREFIX }}-${{ matrix.arch }}-cluster
+          resource-group: ${{ env.AZURE_PREFIX }}-rg
+          admin: false
+      - if: matrix.os != 'ubuntu-latest'
+        # kubectl is already installed in Linux runners
+        uses: azure/setup-kubectl@v3
+      - name: Run integration tests
+        shell: bash
+        run: |
+          make integration-test -o kubectl-az

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LDFLAGS := "-X github.com/Azure/kubectl-az/cmd.version=$(VERSION) -extldflags '-
 
 .DEFAULT_GOAL := kubectl-az
 
+# Build
 KUBECTL_AZ_TARGETS = \
 	kubectl-az-linux-amd64 \
 	kubectl-az-linux-arm64 \
@@ -48,11 +49,24 @@ kubectl-az-%: phony_explicit
 		-o kubectl-az-$${GOOS}-$${GOARCH} \
 		github.com/Azure/kubectl-az
 
+# Install
 .PHONY: install
 install: kubectl-az
 	mkdir -p ~/.local/bin/
 	cp kubectl-az ~/.local/bin/
 
+# Run unit tests
+.PHONY: unit-test
+unit-test:
+	go test -v ./...
+
+# Run integration tests
+.PHONY: integration-test
+integration-test: kubectl-az
+	KUBECTL_AZ="$(shell pwd)/kubectl-az" \
+		go test -v ./test/integration/... -integration
+
+# Clean
 .PHONY: clean
 clean:
 	rm -f kubectl-az

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/kinvolk/inspektor-gadget/pkg/k8sutil"
+	"github.com/stretchr/testify/require"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func runKubectlAZ(t *testing.T, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(os.Getenv("KUBECTL_AZ"), append(nodeFlag(t), args...)...)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	t.Logf("Running command: %s", cmd.String())
+	err := cmd.Run()
+	require.Empty(t, stderr.String(), "stderr.String() = %v, want empty", stderr.String())
+	require.Nil(t, err, "cmd.Run() = %v, want nil", err)
+	t.Logf("Command output: \n%s", stdout.String())
+
+	return stdout.String()
+}
+
+func nodeFlag(t *testing.T) []string {
+	t.Helper()
+
+	clientset, err := k8sutil.NewClientsetFromConfigFlags(genericclioptions.NewConfigFlags(false))
+	require.Nil(t, err, "k8sutil.NewClientsetFromConfigFlags() = %v, want nil", err)
+
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metaV1.ListOptions{})
+	require.Nil(t, err, "clientset.CoreV1().Nodes().List() = %v, want nil", err)
+	require.NotEmpty(t, nodes.Items, "nodes.Items = %v, want not empty", nodes.Items)
+
+	return []string{"--node", nodes.Items[0].Name}
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package integration
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var integration = flag.Bool("integration", false, "run integration tests")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !*integration {
+		fmt.Println("Skipping integration test.")
+		os.Exit(0)
+	}
+
+	if os.Getenv("KUBECTL_AZ") == "" {
+		fmt.Fprintf(os.Stderr, "KUBECTL_AZ environment variable must be set to the path of the kubectl-az binary\n")
+		os.Exit(1)
+	}
+
+	fmt.Println("Running integration tests")
+	m.Run()
+}
+
+func TestCheckAPIServerConnectivity(t *testing.T) {
+	out := runKubectlAZ(t, "check-apiserver-connectivity")
+	require.Contains(t, out, "Connectivity check: succeeded")
+}
+
+func TestRunCommand(t *testing.T) {
+	// test stdout
+	out := runKubectlAZ(t, "run-command", "echo test")
+	stdout, stderr := parseRunCommand(t, out)
+	require.Equal(t, stdout, "test", "parseRunCommand() = %v, want %v", stdout, "test")
+	require.Empty(t, stderr, "parseRunCommand() = %v, want %v", stderr, "")
+
+	// test stderr
+	out = runKubectlAZ(t, "run-command", "echo test >&2")
+	stdout, stderr = parseRunCommand(t, out)
+	require.Empty(t, stdout, "parseRunCommand() = %v, want %v", stdout, "")
+	require.Equal(t, stderr, "test", "parseRunCommand() = %v, want %v", stderr, "test")
+}
+
+func parseRunCommand(t *testing.T, out string) (string, string) {
+	split := regexp.MustCompile(`(\[(stdout|stderr)\])`).Split(out, -1)
+	require.Len(t, split, 3, "couldn't parse response message:\n%s", out)
+	stdOutput := strings.TrimSpace(split[1])
+	stdError := strings.TrimSpace(split[2])
+	return stdOutput, stdError
+}


### PR DESCRIPTION
This PR introduces CI with integration tests for `kubectl-az`. The idea is to create a single AKS cluster and use `kubectl-az` clients from different OS to test if everything works as expected. Since we use a single AKS cluster the tests should run serially (should be fine in the start). 

## Testing Done

Tests are passing for:
- [Linux](https://github.com/Azure/kubectl-az/actions/runs/4608539916/jobs/8144589221#step:10:98)
- [Windows](https://github.com/Azure/kubectl-az/actions/runs/4608539916/jobs/8144589719#step:10:99)
- [MacOS](https://github.com/Azure/kubectl-az/actions/runs/4608539916/jobs/8144589504#step:10:100)